### PR TITLE
modifiy string_std function

### DIFF
--- a/R/string_std.R
+++ b/R/string_std.R
@@ -22,7 +22,7 @@
 #' @export string_std
 string_std <- function(x) {
   x <- tolower(x)
-  x <- gsub("[[:space:]]+|[[:punct:]]+", "_", x)
+  x <- gsub("[^[:alnum:]]+", "_", x)
   x <- stringi::stri_trans_general(x, id = "Latin-ASCII")
   x
 }


### PR DESCRIPTION
I noticed that running the current `string_std` function on something like `"Karangasso - Vigue"` will return:
```r
#> [1] "karangasso___vigue" # 3 underscores 
```

I think it would be preferable to convert a `" - "` separator to a single underscore so I've tweaked the code to do that:

``` r
hmatch::string_std("Karangasso - Vigue")
#> [1] "karangasso_vigue"
```
